### PR TITLE
Modifies Entity#attributes to return only attributes declared via attr_accessor

### DIFF
--- a/lib/entity.rb
+++ b/lib/entity.rb
@@ -1,19 +1,29 @@
 class Entity
   attr_accessor :id, :created_at, :updated_at
 
+  def self.attr_accessor(*args)
+    add_accessible_attributes(*args)
+    super
+  end
+
+  def self.add_accessible_attributes(*args)
+    accessible_attributes.concat(args)
+  end
+
+  def self.accessible_attributes
+    @accessible_attributes ||= []
+  end
+
   def initialize(attributes = {})
     attributes.each do |field, value|
-      method_name = "#{field.to_s}=".to_sym
+      method_name = "#{field}=".to_sym
       send(method_name, value) if self.methods.include?(method_name)
     end
   end
 
   def attributes
-    attrs = Hash.new
-    instance_variables.each do |variable|
-      key = variable[1..-1].to_sym
-      attrs[key] = instance_variable_get(variable)
+    self.class.accessible_attributes.each_with_object({}) do |variable, attrs|
+      attrs[variable.to_sym] = public_send(variable)
     end
-    attrs
   end
 end

--- a/spec/lib/entity_spec.rb
+++ b/spec/lib/entity_spec.rb
@@ -1,12 +1,12 @@
+# frozen_string_literal: true
+
 require_relative '../../lib/entity'
 
-class TestHarness < Entity
-  attr_accessor :name
-end
-
 describe Entity do
+  let(:test_harness_class) { Class.new(Entity) { attr_accessor :name } }
+
   describe 'an invalid attribute given' do
-    subject(:test_harness) { TestHarness.new(invalid_attribute: true) }
+    subject(:test_harness) { test_harness_class.new(invalid_attribute: true) }
 
     it 'does not raise an error' do
       expect { test_harness }.not_to raise_error
@@ -14,10 +14,43 @@ describe Entity do
   end
 
   describe 'a valid attribute given' do
-    subject(:test_harness) { TestHarness.new(name: 'Mickey Mouse')}
+    subject(:test_harness) { test_harness_class.new(name: 'Mickey Mouse') }
 
     it 'assigns attribute correctly' do
       expect(test_harness.name).to eq('Mickey Mouse')
+    end
+  end
+
+  describe '#attributes' do
+    subject(:attributes) { test_harness.attributes }
+
+    context 'when some attributes are not provided' do
+      let(:test_harness_class) { Class.new(Entity) { attr_accessor :name, :species } }
+      let(:test_harness) { test_harness_class.new(name: 'Donald Duck') }
+
+      it 'returns all assigned and unassigned attributes' do
+        expect(attributes).to eq(name: 'Donald Duck', species: nil)
+      end
+    end
+
+    context 'when the entity has private instance variables' do
+      let(:test_harness_class) do
+        Class.new(Entity) do
+          attr_accessor :name
+
+          def do_something
+            @private_instance_variable = 'keep track of something'
+          end
+        end
+      end
+
+      let(:test_harness) { test_harness_class.new(name: 'Goofy') }
+
+      before { test_harness.do_something }
+
+      it 'does not return private instance variables' do
+        expect(attributes).to eq(name: 'Goofy')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR covers a couple of edge cases with `Entity#attributes`
I'm making the following assumptions about calling `Entity#attributes`
- It should return all attributes declared via `attr_accessor`, even the ones that have not been set
- It should NOT return private instance variables that do not correspond to an `attr_accessor`